### PR TITLE
Feature/leaderboard

### DIFF
--- a/src/app/api/battle/update-score/route.ts
+++ b/src/app/api/battle/update-score/route.ts
@@ -1,57 +1,57 @@
 import { NextRequest, NextResponse } from 'next/server';
 import pool from '@/lib/db';
-import { addScore } from "@/lib/leaderboard";
-
+import { addScore } from '@/lib/leaderboard';
 
 export async function POST(request: NextRequest) {
   const client = await pool.connect();
-  
+
   try {
-    const body = await request.json();
-    const { userId, result } = body; // 'win' ili 'lose'
+    const { userId, result } = (await request.json()) as {
+      userId?: number;
+      result?: 'win' | 'draw' | 'lose'; // 'win' ili 'lose'
+    };
 
     if (!userId || !result) {
-      return NextResponse.json(
-        { success: false, error: 'Missing userId or result' },
-        { status: 400 }
-      );
+      return NextResponse.json({ success: false, error: 'Missing userId or result' }, { status: 400 });
     }
 
     // Odredi score change
-    const scoreChange = result === 'win' ? 100 : -50;
+    const scoreChange =
+      result === 'win'  ? 100 :
+      result === 'draw' ? 50  :
+                          -50;
 
     // Update user score u bazi
     const updateResult = await client.query(
-      `UPDATE users 
-       SET userscore = GREATEST(0, userscore + $1) -- Osiguraj da score ne bude negativan
-       WHERE id = $2 
+      `UPDATE users
+         SET userscore = GREATEST(0, userscore + $1)
+       WHERE id = $2
        RETURNING id, name, userscore`,
       [scoreChange, userId]
     );
 
     if (updateResult.rows.length === 0) {
-      return NextResponse.json(
-        { success: false, error: 'User not found' },
-        { status: 404 }
-      );
+      return NextResponse.json({ success: false, error: 'User not found' }, { status: 404 });
     }
 
     const updatedUser = updateResult.rows[0];
 
-   try {
+    // best-effort: update public leaderboard with the new TOTAL
+    try {
       await addScore({ username: updatedUser.name, score: updatedUser.userscore });
     } catch (e) {
-      console.error("Non-fatal: failed to append leaderboard row", e);
+      console.error('Non-fatal: failed to upsert leaderboard row', e);
     }
-
 
     return NextResponse.json({
       success: true,
-      message: `Score ${result === 'win' ? 'increased' : 'decreased'} by ${Math.abs(scoreChange)}`,
+      message:
+        result === 'lose'
+          ? `Score decreased by ${Math.abs(scoreChange)}`
+          : `Score increased by ${Math.abs(scoreChange)}`,
       newScore: updatedUser.userscore,
-      user: updatedUser
+      user: updatedUser,
     });
-
   } catch (error: any) {
     console.error('Error updating score:', error);
     return NextResponse.json(
@@ -62,3 +62,6 @@ export async function POST(request: NextRequest) {
     client.release();
   }
 }
+
+
+

--- a/src/app/api/leaderboard/route.ts
+++ b/src/app/api/leaderboard/route.ts
@@ -11,24 +11,15 @@ export async function GET() {
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
+    // optional quick validation (lib also validates):
+    LeaderboardInsert.parse(body);
 
-    // quick validation feedback (optional, not required because addScore validates too)
-    const parsed = LeaderboardInsert.safeParse(body);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { ok: false, error: parsed.error.flatten() },
-        { status: 400 }
-      );
-    }
-
-    const row = await addScore(parsed.data);
+    const row = await addScore(body); // uses the lib function
     return NextResponse.json({ ok: true, row }, { status: 201 });
-  } catch (err: any) {
-    // if Zod throws inside addScore
-    if (err?.name === "ZodError") {
-      return NextResponse.json({ ok: false, error: err.issues }, { status: 400 });
-    }
-    console.error("POST /api/leaderboard failed:", err);
-    return NextResponse.json({ ok: false, error: "Internal error" }, { status: 500 });
+  } catch (e: any) {
+    return NextResponse.json(
+      { ok: false, error: e?.message ?? "invalid payload" },
+      { status: 400 }
+    );
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -24,3 +24,36 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Leaderboard responsive tweaks */
+.leaderboard { padding-inline: 0.75rem; }
+
+/* phones */
+@media (max-width: 640px) {
+  .lb-item {
+    display: flex;              /* override grid on tiny screens */
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.5rem;
+  }
+
+  /* hide avatar circle on tiny screens */
+  .lb-item .h-9.w-9 { display: none; }
+
+  /* let name/date shrink nicely */
+  .lb-item .min-w-0 { flex: 1 1 auto; }
+  .lb-item .truncate { font-size: 0.95rem; }
+  .lb-item .text-xs { font-size: 0.72rem; }
+
+  /* keep medal tight */
+  .lb-item > .col-span-2,
+  .lb-item > .sm\:col-span-1 { flex: 0 0 auto; }
+
+  /* pin score chip to the right */
+  .lb-score { margin-left: auto; }
+}
+
+/* tablets */
+@media (min-width: 641px) and (max-width: 1024px) {
+  .lb-item { grid-template-columns: 1fr 6fr 2fr; }
+}

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -52,22 +52,22 @@ return (
     <div className="min-h-screen bg-[#CCCCCC]">
         <section className=" leaderboard mx-auto max-w-4xl px-4 py-10">
             {/* PANEL WITH TOP TAB TITLE */}
-            <div className="relative rounded-[24px] border-2 border-indigo-200 bg-blue-500 shadow-xl">
+            <div className="relative rounded-[24px] border-2 border-indigo-200 bg-gradient-to-r from-blue-500 to-purple-600 shadow-xl">
             {/* tab title chip */}
             <div className="absolute -top-5 left-1/2 -translate-x-1/2">
-                <div className="rounded-full border border-indigo-200 bg-blue-300 px-10 py-2 font-semibold tracking-wide text-indigo-700 shadow-md">
+                <div className="rounded-full border border-indigo-200 bg-gradient-to-r to-blue-400 from-cyan-300 text-[#333333] px-10 py-2 font-semibold tracking-wide text-indigo-700 shadow-md">
                 LEADERBOARD
                 </div>
             </div>
 
             <div className="px-5 pt-8 pb-5">
-                <p className="mb-4 text-center text-xs text-neutral-500">
+                <p className="mb-4 text-center text-xs text-[#333333]">
                 Top trainers by battle score
                 </p>
 
                 {!hasRows ? (
                 <div className="rounded-2xl border border-neutral-200 bg-white p-8 text-center">
-                    <p className="text-neutral-600">
+                    <p className="text-[#333333]">
                     No scores yet. Finish a battle to post your first score!
                     </p>
                 </div>
@@ -100,7 +100,7 @@ return (
 
                         {/* score pill on the right */}
                         <div className="col-span-2 flex justify-end">
-                        <span className="inline-flex items-center rounded-full bg-indigo-600 px-3 py-1 text-sm font-semibold text-white shadow">
+                        <span className="inline-flex items-center rounded-full bg-blue-400 px-3 py-1 text-sm font-semibold text-white shadow">
                             {row.score.toLocaleString()}
                         </span>
                         </div>

--- a/src/app/leaderboard/page.tsx
+++ b/src/app/leaderboard/page.tsx
@@ -47,55 +47,73 @@ export default async function LeaderboardPage() {
 
   const hasRows = rows.length > 0;
 
-  return (
-    <section className="space-y-6">
-      <header>
-        <h1 className="text-3xl font-semibold tracking-tight">Leaderboard</h1>
-        <p className="mt-1 text-sm text-gray-500">Top trainers by battle score</p>
-      </header>
-
-      {!hasRows ? (
-        <div className="rounded-2xl border bg-white p-8 text-center">
-          <p className="text-gray-600">
-            No scores yet. Finish a battle to post your first score!
-          </p>
-        </div>
-      ) : (
-        <div className="overflow-hidden rounded-2xl border bg-white">
-          <ul className="divide-y">
-            {rows.map((row) => (
-              <li
-                key={row.rank}
-                className="grid grid-cols-12 items-center gap-3 px-4 py-3 odd:bg-white even:bg-gray-50"
-              >
-                {/* Rank / medal */}
-                <div className="col-span-2 sm:col-span-1 flex items-center">
-                  <Medal rank={row.rank} />
+ 
+return (
+    <div className="min-h-screen bg-[#CCCCCC]">
+        <section className=" leaderboard mx-auto max-w-4xl px-4 py-10">
+            {/* PANEL WITH TOP TAB TITLE */}
+            <div className="relative rounded-[24px] border-2 border-indigo-200 bg-blue-500 shadow-xl">
+            {/* tab title chip */}
+            <div className="absolute -top-5 left-1/2 -translate-x-1/2">
+                <div className="rounded-full border border-indigo-200 bg-blue-300 px-10 py-2 font-semibold tracking-wide text-indigo-700 shadow-md">
+                LEADERBOARD
                 </div>
+            </div>
 
-                {/* Avatar + Username */}
-                <div className="col-span-6 sm:col-span-7 flex items-center gap-3">
-                  <div className="h-9 w-9 rounded-full bg-gray-200" aria-hidden />
-                  <div className="min-w-0">
-                    <div className="truncate font-medium text-gray-900">
-                      {row.username}
-                    </div>
-                    <div className="text-xs text-gray-500">{row.date}</div>
-                  </div>
+            <div className="px-5 pt-8 pb-5">
+                <p className="mb-4 text-center text-xs text-neutral-500">
+                Top trainers by battle score
+                </p>
+
+                {!hasRows ? (
+                <div className="rounded-2xl border border-neutral-200 bg-white p-8 text-center">
+                    <p className="text-neutral-600">
+                    No scores yet. Finish a battle to post your first score!
+                    </p>
                 </div>
+                ) : (
+                // LIST CARD BODY
+                <ul className="space-y-3">
+                    {rows.map((row) => (
+                    // ROW = rounded bar + light border, like the mock
+                    <li
+                        key={row.rank}
+                        className="grid grid-cols-12 items-center gap-3 rounded-xl border border-neutral-200 bg-indigo-100 px-4 py-3 hover:bg-neutral-100 transition-colors"
+                    >
+                        {/* rank/medal */}
+                        <div className="col-span-1 flex items-center">
+                        <Medal rank={row.rank} />
+                        </div>
 
+                        {/* avatar + name/date */}
+                        <div className="col-span-9 sm:col-span-9 md:col-span-9 lg:col-span-9 flex items-center gap-3">
+                        <div className="h-8 w-8 rounded-full bg-neutral-200" aria-hidden />
+                        <div className="min-w-0">
+                            <div className="truncate font-medium text-neutral-900">
+                            {row.username}
+                            </div>
+                            <div className="text-[11px] text-neutral-500 leading-tight">
+                            {row.date}
+                            </div>
+                        </div>
+                        </div>
 
-                {/* Score pill (right-aligned) */}
-                <div className="col-span-4 sm:col-span-4 flex justify-end">
-                  <span className="inline-flex items-center rounded-full bg-indigo-100 px-3 py-1 text-sm font-semibold text-indigo-700">
-                    {row.score.toLocaleString()}
-                  </span>
-                </div>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-    </section>
-  );
+                        {/* score pill on the right */}
+                        <div className="col-span-2 flex justify-end">
+                        <span className="inline-flex items-center rounded-full bg-indigo-600 px-3 py-1 text-sm font-semibold text-white shadow">
+                            {row.score.toLocaleString()}
+                        </span>
+                        </div>
+                    </li>
+                    ))}
+                </ul>
+                )}
+            </div>
+            </div>
+        </section>
+    </div>
+    );
 }
+
+
+

--- a/src/scripts/create-leaderboard.ts
+++ b/src/scripts/create-leaderboard.ts
@@ -58,7 +58,23 @@ async function main() {
             CREATE INDEX IF NOT EXISTS idx_leaderboard_score_created
             On leaderboard (score DESC, created_at DESC NULLS LAST);
             `)
-        console.log("✅ leaderboard table ready");;
+            console.log("✅ leaderboard table ready");;
+        
+        // Ensure username is unique (so we can upsert by username)
+        await pool.query(`
+        DO $$
+        BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conname = 'leaderboard_username_key'
+        ) THEN
+            ALTER TABLE leaderboard
+            ADD CONSTRAINT leaderboard_username_key UNIQUE (username);
+        END IF;
+        END
+        $$;
+        `);
+
         
     } catch (e:any) {
         console.error("❌ Failed to create leaderboard table:", e.message);

--- a/src/scripts/dedupe-leaderboard.ts
+++ b/src/scripts/dedupe-leaderboard.ts
@@ -1,0 +1,30 @@
+import { config } from "dotenv";
+import path from "path";
+config({ path: path.resolve(process.cwd(), ".env.local") });
+
+async function main() {
+  const client = await import("../lib/db.js");
+  const pool = client.default;
+
+  try {
+    console.log("🧹 Removing duplicates (keep highest score, then newest) …");
+    await pool.query(`
+      DELETE FROM leaderboard l
+      WHERE l.id NOT IN (
+        SELECT id FROM (
+          SELECT DISTINCT ON (username)
+                 id
+          FROM leaderboard
+          ORDER BY username, score DESC, created_at DESC
+        ) keepers
+      )
+    `);
+    console.log("✅ Dedupe complete.");
+  } catch (e:any) {
+    console.error("❌ Dedupe failed:", e.message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}
+main();

--- a/src/scripts/seed-leaderboard.ts
+++ b/src/scripts/seed-leaderboard.ts
@@ -16,9 +16,12 @@ async function main() {
       ["Red", 2980]
     );
     await pool.query(
-      `INSERT INTO leaderboard (username, score) VALUES ($1, $2)`,
-      ["Misty", 1756]
+      `INSERT INTO leaderboard (username, score)
+      VALUES ($1, $2)
+      ON CONFLICT (username) DO NOTHING`,
+      ["Red", 2980]
     );
+
     console.log("✅ Seeded two rows.");
   } catch (e: any) {
     console.error("❌ Seed failed:", e.message);


### PR DESCRIPTION
### What’s changed
  - Maps results to score deltas: win +100, draw +50, lose −50; clamps with `GREATEST(0, …)`.
  - Removes duplicate `scoreChange` declaration (build error).

- **Client** `BattleArena`
  - If **logged in**: updates score server-side (no name prompt).
  - If **guest**: one-time prompt (debounced with `useRef`) 
  - Resets debounce on “New Battle”.

- **Leaderboard UI**
  - Layout/spacing updated to better match Pokémon pages (container, responsive grid).
 
- **DB helper** `lib/leaderboard.ts`
  - `addScore` upserts by `username`; only updates `created_at` when a **higher** score is set.
  - `getTop` orders by `score DESC, created_at DESC`.

- **Scripts**
  - `create-leaderboard.ts`: ensures unique index on `username` + composite index `(score DESC, created_at DESC)`.

